### PR TITLE
Trim README files

### DIFF
--- a/packages/blac-react/README.md
+++ b/packages/blac-react/README.md
@@ -1,195 +1,27 @@
 # @blac/react
 
-A powerful React integration for the Blac state management library, providing seamless integration between React components and Blac's reactive state management system.
+React hooks for Blac.
 
-## Features
-
-- 🔄 Automatic re-rendering when relevant state changes
-- 🎯 Fine-grained dependency tracking
-- 🔍 Property access tracking for optimized updates
-- 🎨 TypeScript support with full type inference
-- ⚡️ Efficient state management with minimal boilerplate
-- 🔄 Support for isolated and shared bloc instances
-- 🎯 Custom dependency selectors for precise control
-
-## Important: Arrow Functions Required
-
-All methods in Bloc or Cubit classes must use arrow function syntax (`method = () => {}`) instead of the traditional method syntax (`method() {}`). This is because arrow functions automatically bind `this` to the class instance. Without this binding, methods called from React components would lose their context and could not access instance properties like `this.state` or `this.emit()`.
-
-```tsx
-// Correct way to define methods in your Bloc/Cubit classes
-class CounterBloc extends Cubit<CounterState> {
-  increment = () => {
-    this.emit({ ...this.state, count: this.state.count + 1 });
-  }
-
-  decrement = () => {
-    this.emit({ ...this.state, count: this.state.count - 1 });
-  }
-}
-
-// Incorrect way (will cause issues when called from React):
-class CounterBloc extends Cubit<CounterState> {
-  increment() { // ❌ Will lose 'this' context when called from components
-    this.emit({ ...this.state, count: this.state.count + 1 });
-  }
-}
-```
-
-## Installation
+## Install
 
 ```bash
-npm install @blac/react
-# or
-yarn add @blac/react
-# or
 pnpm add @blac/react
 ```
 
-## Quick Start
+## useBloc
 
 ```tsx
-import { useBloc } from '@blac/react';
-import { CounterBloc } from './CounterBloc';
+import { useBloc } from '@blac/react'
+import { CounterCubit } from './CounterCubit'
 
 function Counter() {
-  const [state, counterBloc] = useBloc(CounterBloc);
-
-  return (
-    <div>
-      <p>Count: {state.count}</p>
-      <button onClick={() => counterBloc.increment()}>Increment</button>
-    </div>
-  );
+  const [state, counter] = useBloc(CounterCubit)
+  return <button onClick={counter.increment}>{state.count}</button>
 }
 ```
 
-## Usage
+Options: `{ id, props, onMount, dependencySelector }`.
 
-### Basic Usage
+Bloc methods should be arrow functions so `this` stays bound.
 
-The `useBloc` hook provides a simple way to connect your React components to Blac's state management system:
-
-```tsx
-const [state, bloc] = useBloc(YourBloc);
-```
-
-### Advanced Configuration
-
-The hook accepts configuration options for more control:
-
-```tsx
-const [state, bloc] = useBloc(YourBloc, {
-  id: 'custom-id', // Optional: Custom identifier for the bloc
-  props: { /* ... */ }, // Optional: Props to pass to the bloc
-  onMount: (bloc) => { /* ... */ }, // Optional: Callback when bloc is mounted (similar to useEffect(<>, []))
-  dependencySelector: (newState, oldState) => [/* ... */], // Optional: Custom dependency tracking
-});
-```
-
-### Dependency Tracking
-
-The hook automatically tracks which state properties are accessed in your component and only triggers re-renders when those specific properties change:
-
-```tsx
-function UserProfile() {
-  const [state, userBloc] = useBloc(UserBloc);
-
-  // Only re-renders when state.name changes
-  return <h1>{state.name}</h1>;
-}
-```
-
-This also works for getters on the Bloc or Cubit class:
-
-```tsx
-function UserProfile() {
-  const [, userBloc] = useBloc(UserBloc);
-
-  // Only re-renders when the return value from the getter formattedName changes
-  return <h1>{userBloc.formattedName}</h1>;
-}
-```
-
-### Custom Dependency Selector
-
-For more control over when your component re-renders, you can provide a custom dependency selector:
-
-```tsx
-const [state, bloc] = useBloc(YourBloc, {
-  dependencySelector: (newState, oldState) => [
-    newState.specificField,
-    newState.anotherField
-  ]
-});
-```
-
-## API Reference
-
-### useBloc Hook
-
-```typescript
-function useBloc<B extends BlocConstructor<BlocGeneric>>(
-  bloc: B,
-  options?: BlocHookOptions<InstanceType<B>>
-): [BlocState<InstanceType<B>>, InstanceType<B>]
-```
-
-#### Options
-
-- `id?: string` - Custom identifier for the bloc instance
-- `props?: InferPropsFromGeneric<B>` - Props to pass to the bloc
-- `onMount?: (bloc: B) => void` - Callback function invoked when the react component (the consumer) is connected to the bloc instance
-- `dependencySelector?: BlocHookDependencyArrayFn<B>` - Function to select dependencies for re-renders
-
-## Best Practices
-
-1. **Use Isolated Blocs**: When you need component-specific state, use isolated blocs:
-   ```tsx
-   class MyIsolatedBloc extends BlocBase {
-     static isolated = true;
-     // ... rest of your bloc implementation
-   }
-   ```
-
-2. **Use Custom Identifiers**: When you need multiple independent instances of the same Bloc type, use custom identifiers to manage different state contexts:
-   ```tsx
-   // In a chat application with multiple chat rooms
-   function ChatRoom({ roomId }: { roomId: string }) {
-     const [state, chatBloc] = useBloc(ChatBloc, {
-       id: `chat-${roomId}`, // Each room gets its own instance
-       props: { roomId }
-     });
-
-     return (
-       <div>
-         <h2>Room: {roomId}</h2>
-         {state.messages.map(msg => (
-           <Message key={msg.id} message={msg} />
-         ))}
-       </div>
-     );
-   }
-
-   // Usage:
-   function ChatApp() {
-     return (
-       <div>
-         <ChatRoom roomId="general" />
-         <ChatRoom roomId="support" />
-       </div>
-     );
-   }
-   ```
-
-3. **Optimize Re-renders**: Let the hook track dependencies automatically unless you have a specific need for custom dependency tracking.
-
-4. **Type Safety**: Take advantage of TypeScript's type inference for better development experience and catch errors early.
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-## License
-
-MIT
+MIT License.

--- a/packages/blac/README.md
+++ b/packages/blac/README.md
@@ -1,260 +1,29 @@
 # @blac/core
 
-A lightweight, flexible state management library for JavaScript/TypeScript applications focusing on predictable state transitions.
+Core state containers for Blac.
 
-## Features
+## Cubit
 
-- 🔄 Predictable unidirectional data flow
-- 🧩 Modular architecture with Blocs and Cubits
-- 🧪 Unit test friendly
-- 🔒 Isolated state instances when needed
-- 🔌 Plugin system for extensibility
-
-## Installation
-
-Install `@blac/core` using your favorite package manager:
-
-```bash
-# pnpm
-pnpm add @blac/core
-
-# yarn
-yarn add @blac/core
-
-# npm
-npm install @blac/core
-```
-
-## Core Concepts
-
-### Blocs and Cubits
-
-**Cubit**: A simple state container with methods to emit new states.
-
-```typescript
+```ts
 class CounterCubit extends Cubit<number> {
+  constructor() { super(0) }
+  increment = () => this.emit(this.state + 1)
+}
+```
+
+## Bloc
+
+```ts
+class Increment {}
+class CounterBloc extends Bloc<number, Increment> {
   constructor() {
-    super(0); // Initial state
+    super(0)
+    this.on(Increment, () => this.emit(this.state + 1))
   }
-
-  increment = () => {
-    this.emit(this.state + 1);
-  }
-
-  decrement = () => {
-    this.emit(this.state - 1);
-  }
+  increment = () => this.add(new Increment())
 }
 ```
 
-**Bloc**: More powerful state container that uses an event-handler pattern for type-safe, event-driven state transitions. Events (instances of classes) are dispatched via `this.add()`, and handlers are registered using `this.on(EventClass, handler)`.
+Use arrow functions so methods keep `this` bound.
 
-```typescript
-// Define event classes
-class IncrementEvent { constructor(public readonly amount: number = 1) {} }
-class DecrementEvent { constructor(public readonly amount: number = 1) {} }
-
-// Optional: Union type for all events
-type CounterEvent = IncrementEvent | DecrementEvent;
-
-class CounterBloc extends Bloc<number, CounterEvent> {
-  constructor() {
-    super(0); // Initial state
-
-    // Register event handlers
-    this.on(IncrementEvent, (event, emit) => {
-      emit(this.state + event.amount);
-    });
-
-    this.on(DecrementEvent, (event, emit) => {
-      emit(this.state - event.amount);
-    });
-  }
-
-  // Helper methods to dispatch event instances (optional)
-  increment = (amount = 1) => {
-    this.add(new IncrementEvent(amount));
-  }
-
-  decrement = (amount = 1) => {
-    this.add(new DecrementEvent(amount));
-  }
-}
-```
-
-### Important: Arrow Functions Required
-
-All methods in Bloc or Cubit classes must use arrow function syntax (`method = () => {}`) instead of the traditional method syntax (`method() {}`). This is because arrow functions automatically bind `this` to the class instance. Without this binding, methods called from React components would lose their context and could not access instance properties like `this.state` or `this.emit()`.
-
-### State Management Patterns
-
-#### Shared State (Default)
-
-By default, bloc instances are shared across all consumers:
-
-```typescript
-class GlobalCounterCubit extends Cubit<number> {
-  constructor() {
-    super(0);
-  }
-  
-  increment = () => {
-    this.emit(this.state + 1);
-  }
-}
-```
-
-#### Isolated State
-
-When each consumer needs its own state instance:
-
-```typescript
-class LocalCounterCubit extends Cubit<number> {
-  static isolated = true; // Each consumer gets its own instance
-  
-  constructor() {
-    super(0);
-  }
-  
-  increment = () => {
-    this.emit(this.state + 1);
-  }
-}
-```
-
-#### Persistent State
-
-Keep state alive even when no consumers are using it:
-
-```typescript
-class PersistentCounterCubit extends Cubit<number> {
-  static keepAlive = true; // State persists even when no consumers
-  
-  constructor() {
-    super(0);
-  }
-  
-  increment = () => {
-    this.emit(this.state + 1);
-  }
-}
-```
-
-## Advanced Usage
-
-### Custom Plugins
-
-Create plugins to add functionality like logging, persistence, or analytics:
-
-```typescript
-import { BlacPlugin, BlacLifecycleEvent, BlocBase } from '@blac/core';
-
-class LoggerPlugin implements BlacPlugin {
-  name = 'LoggerPlugin';
-  
-  onEvent(event: BlacLifecycleEvent, bloc: BlocBase, params?: any) {
-    if (event === BlacLifecycleEvent.STATE_CHANGED) {
-      console.log(`[${bloc._name}] State changed:`, bloc.state);
-    }
-  }
-}
-
-// Add the plugin to Blac
-import { Blac } from '@blac/core';
-Blac.addPlugin(new LoggerPlugin());
-```
-
-### Using Props with Blocs
-
-Blocs can be designed to accept properties through their constructor, allowing for configurable instances. Here's an example of a `UserProfileBloc` that takes a `userId` prop:
-
-```typescript
-import { Bloc } from '@blac/core'; // Or your specific import path
-
-// Define props interface (optional, but good practice)
-interface UserProfileProps {
-  userId: string;
-}
-
-// Define state interface
-interface UserProfileState {
-  loading: boolean;
-  userData: { id: string; name: string; bio?: string } | null;
-  error: string | null;
-}
-
-// Define Event Classes for UserProfileBloc
-class UserProfileFetchEvent {}
-class UserProfileDataLoadedEvent { constructor(public readonly data: any) {} }
-class UserProfileErrorEvent { constructor(public readonly error: string) {} }
-
-type UserProfileEvents = UserProfileFetchEvent | UserProfileDataLoadedEvent | UserProfileErrorEvent;
-
-class UserProfileBloc extends Bloc<UserProfileState, UserProfileEvents, UserProfileProps> {
-  private userId: string;
-
-  constructor(props: UserProfileProps) {
-    super({ loading: true, userData: null, error: null }); // Initial state
-    this.userId = props.userId;
-    this._name = `UserProfileBloc_${this.userId}`;
-
-    // Register event handlers
-    this.on(UserProfileFetchEvent, this.handleFetchUserProfile);
-    this.on(UserProfileDataLoadedEvent, (event, emit) => {
-      emit({ ...this.state, loading: false, userData: event.data, error: null });
-    });
-    this.on(UserProfileErrorEvent, (event, emit) => {
-      emit({ ...this.state, loading: false, error: event.error });
-    });
-
-    // Initial fetch
-    this.add(new UserProfileFetchEvent());
-  }
-
-  private handleFetchUserProfile = async (_event: UserProfileFetchEvent, emit: (state: UserProfileState) => void) => {
-    // Emit loading state directly if not already covered by initial state or another event
-    // For this example, constructor sets loading: true, so an immediate emit here might be redundant
-    // unless an event handler could set loading to false before this runs.
-    // emit({ ...this.state, loading: true }); // Ensure loading is true
-    try {
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
-      const mockUserData = { id: this.userId, name: `User ${this.userId}`, bio: 'Loves Blac states!' };
-      this.add(new UserProfileDataLoadedEvent(mockUserData));
-    } catch (e:any) {
-      this.add(new UserProfileErrorEvent(e.message || 'Failed to fetch user profile'));
-    }
-  }
-  
-  // Public method to re-trigger fetch if needed
-  refetchUserProfile = () => {
-    this.add(new UserProfileFetchEvent());
-  }
-}
-```
-
-## API Reference
-
-### Core Classes
-
-- `BlocBase<S, P>`: Base class for state containers
-- `Cubit<S, P>`: Simple state container with `emit()` and `patch()`
-- `Bloc<S, E, P>`: Event-driven state container with `on(EventClass, handler)` and `add(eventInstance)` methods.
-- `Blac`: Singleton manager for all Bloc instances
-
-### React Hooks
-
-- `useBloc<B>(BlocClass, options?)`: Connect a component to a Bloc
-
-### Lifecycle Events
-
-- `BLOC_CREATED`: When a new Bloc is instantiated
-- `BLOC_DISPOSED`: When a Bloc is disposed
-- `LISTENER_ADDED`: When a state listener is added
-- `LISTENER_REMOVED`: When a state listener is removed
-- `STATE_CHANGED`: When state is updated
-- `BLOC_CONSUMER_ADDED`: When a new consumer starts using a Bloc
-- `BLOC_CONSUMER_REMOVED`: When a consumer stops using a Bloc
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.
+MIT License.

--- a/readme.md
+++ b/readme.md
@@ -1,144 +1,25 @@
-# Blac: Beautiful State Management for React
+# Blac
 
-<p align="center">
-  <img src="./apps/docs/public/logo.svg" alt="Blac Logo" width="150" />
-</p>
+Monorepo for the Blac state manager.
 
-<p align="center">
-  <strong>Lightweight, flexible, and predictable state management for modern React applications.</strong>
-</p>
+Packages:
+- **@blac/core** – core classes.
+- **@blac/react** – React hook.
 
-<p align="center">
-  <a href="https://www.npmjs.com/package/@blac/react"><img src="https://img.shields.io/npm/v/@blac/react.svg" alt="NPM Version"/></a>
-  <a href="https://github.com/your-username/blac/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@blac/react.svg" alt="License"/></a>
-  <!-- Add other badges like build status, code coverage, etc. once CI/CD is set up -->
-  <!-- e.g., <a href="your-ci-link"><img src="your-build-status-badge-url" alt="Build Status"/></a> -->
-</p>
-
-## Overview
-
-Blac is a state management library designed to bring simplicity and power to your React projects. It draws inspiration from established patterns like Redux and the Bloc pattern, while offering a more intuitive API and minimizing boilerplate. At its core, Blac focuses on type safety (with first-class TypeScript support) and an excellent developer experience.
-
-It consists of two main packages:
--   `@blac/core`: The foundational library providing the core Blac/Bloc logic, instance management, and plugin system.
--   `@blac/react`: The React integration layer, offering hooks and utilities to seamlessly connect Blac with your React components.
-
-An **overview** of the Blac pattern, its core concepts, and how it simplifies state management in React.
-
--   **Simple API**: Intuitive and easy to learn, minimizing boilerplate.
--   **Smart Instance Management**: Automatic creation, sharing (default for non-isolated Blocs using class name or provided ID), and disposal of `Bloc` instances. Supports `keepAlive` for persistent state and isolated instances (via `static isolated = true` or unique IDs).
--   **TypeScript First**: Strong typing for robust applications and excellent developer experience.
--   **Extensible**: Add custom functionality through a built-in plugin system or create addons for `Bloc`s (like the `Persist` addon for storage).
--   **Performance**: Lightweight core and efficient updates.
--   **Flexible Architecture**: Adapts to various project needs, from simple components to complex applications.
-
-## Installation
-
-To get started with Blac in your React project, install the `@blac/react` package. This package includes `@blac/core`.
+Install in a project:
 
 ```bash
-# Using pnpm (recommended for this monorepo)
 pnpm add @blac/react
-
-# Or using npm
-npm install @blac/react
-
-# Or using yarn
-yarn add @blac/react
 ```
 
-## Quick Start
+Develop locally:
 
-Here's a taste of how to use Blac with a simple counter:
-
-```tsx
-// 1. Define your Cubit (e.g., in src/cubits/CounterCubit.ts)
-import { Cubit } from '@blac/core';
-
-interface CounterState {
-  count: number;
-}
-
-// CounterCubit manages the counter's state
-export class CounterCubit extends Cubit<CounterState> {
-  constructor() {
-    // Initialize the state with a count of 0
-    super({ count: 0 });
-  }
-
-  // Define methods to update the state
-  // Remember: methods must be arrow functions to bind 'this' correctly!
-  increment = () => this.emit({ count: this.state.count + 1 });
-  decrement = () => this.emit({ count: this.state.count - 1 });
-  reset = () => this.emit({ count: 0 });
-}
-
-// 2. Use the Cubit in your React component (e.g., in src/components/CounterDisplay.tsx)
-import { useBloc } from '@blac/react';
-import { CounterCubit } from '../cubits/CounterCubit'; // Adjust path as needed
-
-function CounterDisplay() {
-  // Connect your component to the CounterCubit.
-  // useBloc returns a tuple: [currentState, cubitInstance]
-  const [state, counterCubit] = useBloc(CounterCubit);
-
-  return (
-    <>
-      <h1>Count: {state.count}</h1> {/* Access state directly */}
-      <button onClick={counterCubit.increment}>Increment</button>
-      <button onClick={counterCubit.decrement}>Decrement</button>
-      <button onClick={counterCubit.reset}>Reset</button>
-    </>
-  );
-}
-
-export default CounterDisplay;
+```bash
+pnpm install
+pnpm test
+pnpm build
 ```
 
-## Core Concepts
+Docs are in `apps/docs`.
 
--   **`BlocBase`**: The foundational abstract class for state containers.
--   **`Cubit<State>`**: A simpler state container that exposes methods (similar to Zustand) to directly `emit` or `patch` new states. The Quick Start example above uses a `Cubit`.
--   **`Bloc<State, Action>`**: A more advanced state container that processes `Action`s (events) through a `reducer` function (similar to Redux reducers) to produce new `State`. This is useful for more complex state logic where transitions are event-driven and require more structure.
--   **`Bloc<State, Event>`**: A more advanced state container that uses an event-handler pattern. It processes event *instances* (typically classes) dispatched via `this.add(new EventType())`. Handlers for specific event classes are registered using `this.on(EventType, handler)`. This approach is useful for complex, type-safe state logic where transitions are event-driven.
--   **`useBloc` Hook**: The primary React hook from `@blac/react` to connect components to `Bloc` or `Cubit` instances, providing the current state and the instance itself. It efficiently re-renders components when relevant state properties change.
--   **Instance Management**: Blac's central `Blac` instance intelligently manages your `Bloc`s/`Cubit`s. By default, non-isolated Blocs are shared (keyed by class name or a custom ID). Blocs can be marked as `static isolated = true` or given unique IDs for component-specific state, and can be configured with `static keepAlive = true` to persist in memory.
-
-## Features In-Depth
-
--   💡 **Simple & Intuitive API**: Get started quickly with familiar concepts and less boilerplate.
--   🧠 **Smart Instance Management** by the central `Blac` class:
-    -   Automatic creation and disposal of `Bloc` instances based on usage.
-    -   Non-isolated `Bloc`s are shared by default (keyed by class name or custom ID).
-    -   Isolated `Bloc`s (marked `static isolated = true` or given a unique ID via `useBloc` options) for component-specific or distinct states.
-    -   `Bloc`s are kept alive as long as they have active listeners/consumers, or if explicitly marked with `static keepAlive = true`.
--   🔒 **TypeScript First**: Full type safety out-of-the-box, enabling robust applications and great autocompletion.
--   🧩 **Extensible via Plugins & Addons**:
-    -   **Plugins**: Extend Blac's core functionality by hooking into lifecycle events (e.g., for logging).
-    -   **Addons**: Enhance individual `Bloc` capabilities (e.g., state persistence with the `Persist` addon).
--   🚀 **Performance Focused**:
-    -   Minimal dependencies for a small bundle size.
-    -   Efficient state updates and re-renders in React.
--   🧱 **Flexible Architecture**: Adapts to various React project structures and complexities.
-
-## Documentation
-
-For comprehensive documentation, including advanced usage, API details, and guides, please refer to:
-
--   **Local Docs**: Run `pnpm run dev:docs` in the `apps/docs` directory and open the provided local URL.
--   **Online Docs**: (TODO: Add link to the deployed documentation site here if available)
-
-## Contributing
-
-Contributions are highly welcome! Whether it's bug fixes, feature enhancements, or documentation improvements, please feel free to:
-1.  Fork the repository.
-2.  Create your feature branch (`git checkout -b feature/AmazingFeature`).
-3.  Commit your changes (`git commit -m 'Add some AmazingFeature'`).
-4.  Push to the branch (`git push origin feature/AmazingFeature`).
-5.  Open a Pull Request.
-
-Please ensure your code adheres to the project's linting and formatting standards.
-
-## License
-
-Blac is [MIT licensed](./LICENSE).
+[MIT License](./LICENSE)


### PR DESCRIPTION
## Summary
- remove marketing text from README files
- keep simple setup and example usage

## Testing
- `pnpm test`