### PR TITLE
Prevent double disposal

### DIFF
--- a/packages/blac/src/BlacObserver.ts
+++ b/packages/blac/src/BlacObserver.ts
@@ -81,7 +81,7 @@ export class BlacObservable<S = unknown> {
     this._observers.delete(observer);
     // Blac.instance.dispatchEvent(BlacLifecycleEvent.LISTENER_REMOVED, this.bloc, { listenerId: observer.id });
 
-    if (this.size === 0) {
+    if (this.size === 0 && !(this.bloc as any)._disposed) {
       Blac.log('BlacObservable.unsubscribe: No observers left. Disposing bloc.', this.bloc);
       this.bloc._dispose();
     }

--- a/packages/blac/src/BlocBase.ts
+++ b/packages/blac/src/BlocBase.ts
@@ -85,6 +85,12 @@ export abstract class BlocBase<
    * Indicates if this specific Bloc instance should be kept alive when no consumers are present.
    */
   public _keepAlive = false;
+
+  /**
+   * @internal
+   * Tracks whether this bloc has been disposed to prevent double cleanup.
+   */
+  private _disposed = false;
   
   /**
    * @readonly
@@ -164,6 +170,8 @@ export abstract class BlocBase<
    * Notifies the Blac manager and clears all observers.
    */
   _dispose() {
+    if (this._disposed) return;
+    this._disposed = true;
     this._observer.clear();
     this.onDispose?.();
     // this._blac.dispatchEvent(BlacLifecycleEvent.BLOC_DISPOSED, this);


### PR DESCRIPTION
## Summary
- add `_disposed` flag to `BlocBase`
- ensure `_dispose` only runs once
- skip disposal from `BlacObservable` when already disposing

## Testing
- `pnpm test`