### PR TITLE
Fix external store dependency selector

### DIFF
--- a/packages/blac-react/src/useExternalBlocStore.ts
+++ b/packages/blac-react/src/useExternalBlocStore.ts
@@ -97,8 +97,12 @@ const useExternalBlocStore = <
             return [[newState]];
           }
 
+          if (usedKeys.current.size === 0 && usedClassPropKeys.current.size === 0) {
+            return [[]];
+          }
+
           // For object states, track which properties were actually used
-          const usedStateValues: string[] = [];
+          const usedStateValues: unknown[] = [];
           for (const key of usedKeys.current) {
             if (key in newState) {
               usedStateValues.push(newState[key as keyof typeof newState]);


### PR DESCRIPTION
## Summary
- short-circuit dependency selector when no state or class keys used
- fix type of `usedStateValues`

## Testing
- `pnpm test`