### PR TITLE
Update docs for selector option

### DIFF
--- a/apps/docs/api/react-hooks.md
+++ b/apps/docs/api/react-hooks.md
@@ -25,7 +25,7 @@ function useBloc<
 | `blocClass` | `BlocConstructor<BlocGeneric>` | Yes | The Bloc/Cubit class to use |
 | `options.id` | `string` | No | Optional identifier for the Bloc/Cubit instance |
 | `options.props` | `InferPropsFromGeneric<B>` | No | Props to pass to the Bloc/Cubit constructor |
-| `options.dependencySelector` | `BlocHookDependencyArrayFn<InstanceType<B>>` | No | Function to select which state properties should trigger re-renders |
+| `options.selector` | `BlocHookDependencyArrayFn<InstanceType<B>>` | No | Function to select which state properties should trigger re-renders (alias `dependencySelector`) |
 | `options.onMount` | `(bloc: InstanceType<B>) => void` | No | Callback function invoked when the Bloc is mounted |
 
 ### Returns
@@ -207,14 +207,14 @@ function ChatThread({ conversationId }: { conversationId: string }) {
 With this approach, you can have multiple independent instances of state that share the same business logic.
 
 ---
-#### Custom Dependency Selector
+#### Custom Selector
 While property access is automatically tracked, in some cases you might want more control over when a component re-renders:
 
 ```tsx
 function OptimizedTodoList() {
-  // Using dependency selector for optimization
+  // Using a custom selector for optimization
   const [state, bloc] = useBloc(TodoBloc, {
-    dependencySelector: (newState, oldState) => [
+    selector: (newState, oldState) => [
       newState.todos.length,
       newState.filter
     ]

--- a/packages/blac-react/README.md
+++ b/packages/blac-react/README.md
@@ -83,7 +83,7 @@ const [state, bloc] = useBloc(YourBloc, {
   id: 'custom-id', // Optional: Custom identifier for the bloc
   props: { /* ... */ }, // Optional: Props to pass to the bloc
   onMount: (bloc) => { /* ... */ }, // Optional: Callback when bloc is mounted (similar to useEffect(<>, []))
-  dependencySelector: (newState, oldState) => [/* ... */], // Optional: Custom dependency tracking
+  selector: (newState, oldState) => [/* ... */], // Optional: Custom dependency tracking
 });
 ```
 
@@ -111,13 +111,13 @@ function UserProfile() {
 }
 ```
 
-### Custom Dependency Selector
+### Custom Selector
 
-For more control over when your component re-renders, you can provide a custom dependency selector:
+For more control over when your component re-renders, you can provide a custom selector:
 
 ```tsx
 const [state, bloc] = useBloc(YourBloc, {
-  dependencySelector: (newState, oldState) => [
+  selector: (newState, oldState) => [
     newState.specificField,
     newState.anotherField
   ]
@@ -140,7 +140,7 @@ function useBloc<B extends BlocConstructor<BlocGeneric>>(
 - `id?: string` - Custom identifier for the bloc instance
 - `props?: InferPropsFromGeneric<B>` - Props to pass to the bloc
 - `onMount?: (bloc: B) => void` - Callback function invoked when the react component (the consumer) is connected to the bloc instance
-- `dependencySelector?: BlocHookDependencyArrayFn<B>` - Function to select dependencies for re-renders
+- `selector?: BlocHookDependencyArrayFn<B>` - Function to select dependencies for re-renders (alias `dependencySelector`)
 
 ## Best Practices
 

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,10 @@ function CounterDisplay() {
 export default CounterDisplay;
 ```
 
+### Customizing Re-renders
+
+`useBloc` accepts an optional `selector` function in its options object. This function allows you to specify which values should trigger a re-render when the bloc state changes. The legacy name `dependencySelector` can also be used as an alias.
+
 ## Core Concepts
 
 -   **`BlocBase`**: The foundational abstract class for state containers.


### PR DESCRIPTION
## Summary
- document `selector` option in README quickstart
- rename `dependencySelector` option to `selector` in `@blac/react` README
- update API docs to use `selector` instead of `dependencySelector`

## Testing
- `pnpm test`