### PR TITLE
Refactor isolated bloc map

### DIFF
--- a/packages/blac/src/Blac.ts
+++ b/packages/blac/src/Blac.ts
@@ -44,7 +44,7 @@ export class Blac {
   /** Map storing all registered bloc instances by their class name and ID */
   blocInstanceMap: Map<string, BlocBase<any>> = new Map();
   /** Map storing isolated bloc instances grouped by their constructor */
-  isolatedBlocMap: Map<BlocConstructor<any>, BlocBase<any>[]> = new Map();
+  isolatedBlocMap: Map<BlocConstructor<any>, Map<BlocInstanceId, BlocBase<any>>> = new Map();
   /** Flag to control whether changes should be posted to document */
   postChangesToDocument = false;
 
@@ -119,8 +119,8 @@ export class Blac {
       bloc._dispose();
     });
 
-    oldIsolatedBlocMap.forEach((blocArray) => {
-      blocArray.forEach((bloc) => {
+    oldIsolatedBlocMap.forEach((blocMap) => {
+      blocMap.forEach((bloc) => {
         bloc._dispose();
       });
     });
@@ -205,12 +205,12 @@ export class Blac {
    */
   registerIsolatedBlocInstance(bloc: BlocBase<any>): void {
     const blocClass = bloc.constructor as BlocConstructor<unknown>;
-    const blocs = this.isolatedBlocMap.get(blocClass);
-    if (blocs) {
-      blocs.push(bloc);
-    } else {
-      this.isolatedBlocMap.set(blocClass, [bloc]);
+    let blocMap = this.isolatedBlocMap.get(blocClass);
+    if (!blocMap) {
+      blocMap = new Map();
+      this.isolatedBlocMap.set(blocClass, blocMap);
     }
+    blocMap.set(bloc._id, bloc);
   }
 
   /**
@@ -218,17 +218,12 @@ export class Blac {
    * @param bloc - The isolated bloc instance to unregister
    */
   unregisterIsolatedBlocInstance(bloc: BlocBase<any>): void {
-    const blocClass = bloc.constructor;
-    const blocs = this.isolatedBlocMap.get(blocClass as BlocConstructor<unknown>);
-    if (blocs) {
-      const index = blocs.findIndex((b) => b._id === bloc._id);
-      if (index !== -1) {
-        blocs.splice(index, 1);
-      }
-
-      if (blocs.length === 0) {
-        this.isolatedBlocMap.delete(blocClass as BlocConstructor<unknown>);
-      }
+    const blocClass = bloc.constructor as BlocConstructor<unknown>;
+    const map = this.isolatedBlocMap.get(blocClass);
+    if (!map) return;
+    map.delete(bloc._id);
+    if (map.size === 0) {
+      this.isolatedBlocMap.delete(blocClass);
     }
   }
 
@@ -242,13 +237,11 @@ export class Blac {
     const base = blocClass as unknown as BlocBaseAbstract;
     if (!base.isolated) return undefined;
 
-    const blocs = this.isolatedBlocMap.get(blocClass);
-    if (!blocs) {
+    const blocMap = this.isolatedBlocMap.get(blocClass);
+    if (!blocMap) {
       return undefined;
     }
-    // Fix: Find the specific bloc by ID within the isolated array
-    const found = blocs.find((b) => b._id === id) as InstanceType<B> | undefined;
-    return found;
+    return blocMap.get(id) as InstanceType<B> | undefined;
   }
 
   /**
@@ -393,12 +386,24 @@ export class Blac {
       searchIsolated?: boolean;
     } = {},
   ): InstanceType<B>[] => {
+    const base = blocClass as unknown as BlocBaseAbstract;
+
+    // Fast path for isolated blocs - they can't exist in the main map
+    if (base.isolated && options.searchIsolated !== false) {
+      const isolatedBlocs = this.isolatedBlocMap.get(blocClass);
+      if (!isolatedBlocs) return [];
+      const results: InstanceType<B>[] = [];
+      isolatedBlocs.forEach((bloc) => {
+        results.push(bloc as InstanceType<B>);
+      });
+      return results;
+    }
+
     const results: InstanceType<B>[] = [];
-    // const blocClassName = (blocClass as any).name; // Temporarily removed for debugging
 
     // Search non-isolated blocs
     this.blocInstanceMap.forEach((blocInstance) => {
-      if (blocInstance.constructor === blocClass) { // Strict constructor check
+      if (blocInstance.constructor === blocClass) {
         results.push(blocInstance as InstanceType<B>);
       }
     });
@@ -407,7 +412,9 @@ export class Blac {
     if (options.searchIsolated !== false) {
       const isolatedBlocs = this.isolatedBlocMap.get(blocClass);
       if (isolatedBlocs) {
-        results.push(...isolatedBlocs.map(bloc => bloc as InstanceType<B>));
+        isolatedBlocs.forEach((bloc) => {
+          results.push(bloc as InstanceType<B>);
+        });
       }
     }
 

--- a/packages/blac/tests/Blac.test.ts
+++ b/packages/blac/tests/Blac.test.ts
@@ -95,8 +95,8 @@ describe('Blac', () => {
       const blac = new Blac();
       const bloc = new ExampleBloc(undefined);
       blac.registerIsolatedBlocInstance(bloc);
-      const blocs = blac.isolatedBlocMap.get(ExampleBloc);
-      expect(blocs).toEqual([bloc]);
+      const blocMap = blac.isolatedBlocMap.get(ExampleBloc);
+      expect(blocMap?.get(bloc._id)).toBe(bloc);
     });
   });
 
@@ -105,8 +105,8 @@ describe('Blac', () => {
       const blac = new Blac();
       const bloc = new ExampleBloc(undefined);
       blac.registerIsolatedBlocInstance(bloc);
-      const blocs = blac.isolatedBlocMap.get(ExampleBloc);
-      expect(blocs).toEqual([bloc]);
+      const map = blac.isolatedBlocMap.get(ExampleBloc);
+      expect(map?.get(bloc._id)).toBe(bloc);
 
       blac.unregisterIsolatedBlocInstance(bloc);
       expect(blac.isolatedBlocMap.get(ExampleBloc)).toBe(undefined);
@@ -154,8 +154,8 @@ describe('Blac', () => {
     it('should register the bloc as isolated if the bloc is isolated', () => {
       const blac = new Blac();
       const bloc = blac.createNewBlocInstance(ExampleBlocIsolated, 'foo');
-      const blocs = blac.isolatedBlocMap.get(ExampleBlocIsolated);
-      expect(blocs).toEqual([bloc]);
+      const map = blac.isolatedBlocMap.get(ExampleBlocIsolated);
+      expect(map?.get(bloc._id)).toBe(bloc);
     });
   });
 
@@ -213,6 +213,20 @@ describe('Blac', () => {
       const idMap = result.map((b) => b._id);
       expect(idMap).toEqual(['foo1', 'foo2', 'foo3']);
     });
+
+    it('should skip non-isolated registry when the bloc class is isolated', () => {
+      const blac = new Blac();
+      for (let i = 0; i < 5; i++) {
+        blac.createNewBlocInstance(ExampleBloc, `bar${i}`);
+      }
+      blac.createNewBlocInstance(ExampleBlocIsolated, 'foo1');
+      blac.createNewBlocInstance(ExampleBlocIsolated, 'foo2');
+
+      const forEachSpy = vi.spyOn(blac.blocInstanceMap, 'forEach');
+      const result = blac.getAllBlocs(ExampleBlocIsolated);
+      expect(result.map((b) => b._id)).toEqual(['foo1', 'foo2']);
+      expect(forEachSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('disposeBloc', () => {
@@ -232,6 +246,41 @@ describe('Blac', () => {
       blac.disposeBloc(bloc);
       expect(spy).toHaveBeenCalled();
       expect(spy).toHaveBeenCalledWith(bloc);
+    });
+
+    it('should remove the bloc from its registry on dispose', () => {
+      const blac = new Blac();
+      const bloc = blac.createNewBlocInstance(ExampleBloc, 'foo');
+      const iso = blac.createNewBlocInstance(ExampleBlocIsolated, 'bar');
+
+      const key = blac.createBlocInstanceMapKey(bloc._name, bloc._id);
+      expect(blac.blocInstanceMap.get(key)).toBe(bloc);
+      expect(blac.isolatedBlocMap.get(ExampleBlocIsolated)?.get(iso._id)).toBe(iso);
+
+      blac.disposeBloc(bloc);
+      blac.disposeBloc(iso);
+
+      expect(blac.blocInstanceMap.get(key)).toBeUndefined();
+      expect(blac.isolatedBlocMap.get(ExampleBlocIsolated)).toBeUndefined();
+    });
+  });
+
+  describe('resetInstance', () => {
+    it('should dispose all blocs and clear registries', () => {
+      const blac = new Blac();
+      const bloc = blac.createNewBlocInstance(ExampleBloc, 'foo');
+      const isoBloc = blac.createNewBlocInstance(ExampleBlocIsolated, 'bar');
+
+      const disposeSpy1 = vi.spyOn(bloc, '_dispose');
+      const disposeSpy2 = vi.spyOn(isoBloc, '_dispose');
+
+      blac.resetInstance();
+      const newBlac = Blac.getInstance();
+
+      expect(disposeSpy1).toHaveBeenCalled();
+      expect(disposeSpy2).toHaveBeenCalled();
+      expect(newBlac.blocInstanceMap.size).toBe(0);
+      expect(newBlac.isolatedBlocMap.size).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- store isolated blocs in nested Map to avoid linear searches
- adapt Blac instance reset logic to iterate nested Maps
- update bloc registration helpers
- iterate map efficiently in `getAllBlocs`
- add tests for registry cleanup and optimized `getAllBlocs`

## Testing
- `npm test --silent`