### PR TITLE
Fix useBloc tracking when selector provided

### DIFF
--- a/packages/blac-react/src/useBloc.tsx
+++ b/packages/blac-react/src/useBloc.tsx
@@ -87,6 +87,10 @@ export default function useBloc<B extends BlocConstructor<BlocBase<any>>>(
   );
 
   const returnState = useMemo(() => {
+    if (options?.selector) {
+      return state;
+    }
+
     return typeof state === 'object'
       ? new Proxy(state, {
           get(_, prop) {
@@ -99,6 +103,10 @@ export default function useBloc<B extends BlocConstructor<BlocBase<any>>>(
   }, [state]);
 
   const returnClass = useMemo(() => {
+    if (options?.selector) {
+      return instance.current;
+    }
+
     return new Proxy(instance.current, {
       get(_, prop) {
         if (!instance.current) {

--- a/packages/blac-react/src/useExternalBlocStore.ts
+++ b/packages/blac-react/src/useExternalBlocStore.ts
@@ -135,8 +135,10 @@ const useExternalBlocStore = <
         const observer: BlacObserver<BlocState<InstanceType<B>>> = {
           fn: () => {
             try {
-              usedKeys.current = new Set();
-              usedClassPropKeys.current = new Set();
+              if (!selector) {
+                usedKeys.current = new Set();
+                usedClassPropKeys.current = new Set();
+              }
 
               listener(blocInstance.current.state);
             } catch (e) {

--- a/packages/blac-react/tests/useBlocSelectorTracking.test.tsx
+++ b/packages/blac-react/tests/useBlocSelectorTracking.test.tsx
@@ -1,0 +1,29 @@
+import { Cubit } from '@blac/core';
+import { renderHook } from '@testing-library/react';
+import { useSyncExternalStore } from 'react';
+import { expect, test } from 'vitest';
+import { externalBlocStore } from '../src';
+
+class CounterCubit extends Cubit<{ count: number }> {
+  static isolated = true;
+  constructor() {
+    super({ count: 0 });
+  }
+}
+
+test('usedKeys remains empty when selector is provided', () => {
+  const selector = () => [];
+  const { result } = renderHook(() => {
+    const { externalStore, usedKeys } = externalBlocStore(CounterCubit, { selector });
+    const state = useSyncExternalStore(
+      externalStore.subscribe,
+      externalStore.getSnapshot,
+      externalStore.getServerSnapshot,
+    );
+    // Access state to potentially trigger tracking
+    void state.count;
+    return usedKeys;
+  });
+
+  expect(result.current.current.size).toBe(0);
+});


### PR DESCRIPTION
## Summary
- skip Proxy tracking in useBloc when a `selector` option is passed
- avoid clearing tracking sets when a selector is in use
- add regression test for usedKeys tracking with selector

## Testing
- `pnpm --filter @blac/react exec vitest run --config vitest.config.ts`
